### PR TITLE
Incorrect L2 normalisation computation

### DIFF
--- a/src/clj/clojurewerkz/statistiker/scaling.clj
+++ b/src/clj/clojurewerkz/statistiker/scaling.clj
@@ -1,6 +1,6 @@
 (ns clojurewerkz.statistiker.scaling
   (:require [clojurewerkz.statistiker.statistics :refer [mean sd]]
-            [clojurewerkz.statistiker.fast-math :refer [sqr]]))
+            [clojurewerkz.statistiker.fast-math :refer [sqr sqrt]]))
 
 (defn make-rescale-range-fn
   [x xmin xmax]
@@ -58,11 +58,12 @@
   [x]
   (let [sum (->> x
                  (map #(sqr %))
-                 (reduce +))]
+                 (reduce +)
+                 sqrt)]
     #(/ % sum)))
 
 (defn l2-normalize
-  "L2-normalize (divide each element by sum of squares)"
+  "L2-normalize (divide each element by the square root of the sum of squares)"
   [x]
   (mapv (make-l2-normalize-fn x) x))
 

--- a/test/clj/clojurewerkz/statistiker/scaling_test.clj
+++ b/test/clj/clojurewerkz/statistiker/scaling_test.clj
@@ -25,8 +25,8 @@
 
 
 (deftest l2-normalize-test
-  (is (= [(double (/ 10 125))
-          (double (/ 5 125))]
+  (is (= [(double (/ 10 (Math/sqrt 125)))
+          (double (/ 5 (Math/sqrt 125)))]
          (l2-normalize [10 5]))))
 
 


### PR DESCRIPTION
The L2 normalisation was calculated according to the rule "divide each element by sum of squares". However, the correct calculation is to divide by the square root of the sum of squares. This PR fixes that problem and the associated tests.

For reference:
Wikipedia article for p-norm: http://en.wikipedia.org/wiki/Norm_(mathematics)#p-norm
