### PR TITLE
Generalisation for lp-norm

### DIFF
--- a/src/clj/clojurewerkz/statistiker/scaling.clj
+++ b/src/clj/clojurewerkz/statistiker/scaling.clj
@@ -1,6 +1,6 @@
 (ns clojurewerkz.statistiker.scaling
   (:require [clojurewerkz.statistiker.statistics :refer [mean sd]]
-            [clojurewerkz.statistiker.fast-math :refer [sqr sqrt]]))
+            [clojurewerkz.statistiker.fast-math :refer [sqr sqrt pow]]))
 
 (defn make-rescale-range-fn
   [x xmin xmax]
@@ -42,30 +42,28 @@
   [x]
   (mapv (make-standartise-fn x) x))
 
-(defn make-l1-normalize-fn
-  [x]
-  (let [sum (->> x
-                 (map #(Math/abs %))
-                 (reduce +))]
+(defn make-lp-normalize-fn
+  [p x]
+  (let
+    [sum (->> x
+                 (map (comp #(pow % p) #(Math/abs %)))
+                 (reduce +)
+                 (#(pow % (/ 1.0 p))))]
     #(/ % sum)))
+
+(defn lp-normalize
+  [p x]
+  (mapv (make-lp-normalize-fn p x) x))
 
 (defn l1-normalize
   "L1-normalize (divide each element by sum of absolute values)."
   [x]
-  (mapv (make-l1-normalize-fn x) x))
-
-(defn make-l2-normalize-fn
-  [x]
-  (let [sum (->> x
-                 (map #(sqr %))
-                 (reduce +)
-                 sqrt)]
-    #(/ % sum)))
+  (mapv (make-lp-normalize-fn 1 x) x))
 
 (defn l2-normalize
   "L2-normalize (divide each element by the square root of the sum of squares)"
   [x]
-  (mapv (make-l2-normalize-fn x) x))
+  (mapv (make-lp-normalize-fn 2 x) x))
 
 (defn scale-feature
   ([maps key scaled-key scale-fn-factory]

--- a/src/clj/clojurewerkz/statistiker/scaling.clj
+++ b/src/clj/clojurewerkz/statistiker/scaling.clj
@@ -44,6 +44,8 @@
 
 (defn make-lp-normalize-fn
   [p x]
+  {:pre [(pos? p)
+         (integer? p)]}
   (let
     [sum (->> x
                  (map (comp #(pow % p) #(Math/abs %)))

--- a/test/clj/clojurewerkz/statistiker/scaling_test.clj
+++ b/test/clj/clojurewerkz/statistiker/scaling_test.clj
@@ -18,9 +18,9 @@
 
 
 (deftest l1-normalize-test
-  (is (= [(/ 2 10)
-          (/ 2 10)
-          (/ 6 10)]
+  (is (= (map double [(/ 2 10)
+                     (/ 2 10)
+                     (/ 6 10)])
          (l1-normalize [2 2 6]))))
 
 

--- a/test/clj/clojurewerkz/statistiker/scaling_test.clj
+++ b/test/clj/clojurewerkz/statistiker/scaling_test.clj
@@ -19,14 +19,14 @@
 
 (deftest l1-normalize-test
   (is (= (map double [(/ 2 10)
-                     (/ 2 10)
-                     (/ 6 10)])
+                      (/ 2 10)
+                      (/ 6 10)])
          (l1-normalize [2 2 6]))))
 
 
 (deftest l2-normalize-test
-  (is (= [(double (/ 10 (Math/sqrt 125)))
-          (double (/ 5 (Math/sqrt 125)))]
+  (is (= (map double [(/ 10 (Math/sqrt 125))
+                      (/ 5 (Math/sqrt 125))])
          (l2-normalize [10 5]))))
 
 

--- a/test/clj/clojurewerkz/statistiker/scaling_test.clj
+++ b/test/clj/clojurewerkz/statistiker/scaling_test.clj
@@ -16,6 +16,10 @@
           (/ 25  (Math/sqrt 1250))]
          (standartise [50 100]))))
 
+(deftest lp-norm-wrong-param
+   (is (thrown? AssertionError (make-lp-normalize-fn -2 [1 2 3])))
+   (is (thrown? AssertionError (make-lp-normalize-fn 0 [1 2 3])))
+   (is (thrown? AssertionError (make-lp-normalize-fn 3.7 [1 2 3]))))
 
 (deftest l1-normalize-test
   (is (= (map double [(/ 2 10)


### PR DESCRIPTION
L1 and L2 normalisation share a common mathematical function. This PR creates such abstraction and makes l1-normalise and l2-normalise depend on it.
