### PR TITLE
Feature/ami

### DIFF
--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -1,27 +1,43 @@
-(ns clojurewerkz.statistiker.metrics)
+(ns clojurewerkz.statistiker.metrics
+  (:require [clojure.math.combinatorics :refer [cartesian-product]]))
 
 ; Adjusted Mutual Information (AMI) is an adjustment of the Mutual Information (MI) score to account for chance.
 ; AMI(U, V) = [MI(U, V) - E(MI(U, V))] / [max(H(U), H(V)) - E(MI(U, V))]
 ; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
 
-; This metric is independent of the absolute values of the labels: a permutation of the class 
+; This metric is independent of the absolute values of the labels: a permutation of the class
 ; or cluster label values won’t change the score value in any way.
 (defn adjusted_mutual_information
-	[true_labels predicted_labels]
-	{:pre [(= (count true_labels) (count predicted_labels))]}
-	0.0)	
+  [U V]
+  {:pre [(= (count U) (count V))
+         (not-any? coll? U)
+         (not-any? coll? V)]}
+  0.0)
 
-; The Mutual Information is a measure of the similarity between two labels of the same data. 
-; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample 
+; The Mutual Information is a measure of the similarity between two labels of the same data.
+; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample
 ; occurring in cluster V_j, the Mutual Information between clusterings U and V is given as:
 ; MI(U,V)=\sum_{i=1}^R \sum_{j=1}^C P(i,j)\log\frac{P(i,j)}{P(i)P'(j)}
 ; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
 
-; This metric is independent of the absolute values of the labels: a permutation of the class or cluster label 
+; This metric is independent of the absolute values of the labels: a permutation of the class or cluster label
 ; values won’t change the score value in any way.
 (defn mutual_information
-	[true_labels predicted_labels]
-	{:pre [(= (count true_labels) (count predicted_labels))
-		   (not (empty? true_labels))
-		   (not (empty? predicted_labels))]}
-	0.0)
+  [U V]
+  {:pre [(= (count U) (count V))
+         (not-any? coll? U)
+         (not-any? coll? V)]}
+  (let [a (frequencies U)
+        b (frequencies V)
+        n (apply merge-with + (map #(hash-map [%1 %2] 1) U V))
+        N (count U)
+        ;; TODO: Use a fmap.
+        norm_n (into {} (map (fn[[k v]] [k (/ v N)]) n))
+        cells (keys norm_n)]
+    (reduce + (map
+               (fn [[i j]]
+                 (* (norm_n [i j])
+                    (Math/log (/ (norm_n [i j])
+                                         (/ (* (a i) (b j))
+                                            (* N N))))))
+               cells))))

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -1,36 +1,7 @@
 (ns clojurewerkz.statistiker.metrics
   (:require [clojure.math.combinatorics :refer [cartesian-product]]
-            [clojurewerkz.statistiker.entropy :refer [shannon-entropy]]))
-
-
-(defn prot-fact
-  "Protected factorial. Special case: returns 1 if x is zero"
-  [x]
-  {:pre [(>= x 0)]}
-  (if (zero? x)
-    1
-    (loop [n x f 1]
-      (if (= n 1)
-        f
-        (recur (dec n) (* f n))))))
-
-(defn prot-log
-  "Protected-log. Special case: returns 0 if x is not positive."
-  [x]
-  (if (not (pos? x))
-    0
-    (Math/log x)))
-
-(defn prot-shannon-entropy
-  "Shannon entropy measure (inc. protected-logarithms)."
-  [v]
-  (let [sum (reduce + v)]
-    (->> v
-         (map (fn shannon-entropy-step [i]
-                (let [pi (/ i sum)]
-                  (* pi (prot-log pi)))))
-         (reduce +)
-         (* -1))))
+            [clojurewerkz.statistiker.entropy :refer [shannon-entropy]]
+            [clojurewerkz.statistiker.utils :refer [factorial prot-log prot-shannon-entropy]]))
 
 ; The Mutual Information is a measure of the similarity between two labels of the same data.
 ; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample
@@ -67,8 +38,8 @@
   (* (/ nij N)
      (prot-log (/ (* N nij)  (* (a i) (b j))))
      (/
-      (* (prot-fact (a i)) (prot-fact (b j)) (prot-fact (- N (a i))) (prot-fact (- N (b j))))
-      (* (prot-fact N) (prot-fact nij) (prot-fact (- (a i) nij)) (prot-fact (- (b j) nij)) (prot-fact (+ (- N (a i) (b j)) nij))))))
+      (* (factorial (a i)) (factorial (b j)) (factorial (- N (a i))) (factorial (- N (b j))))
+      (* (factorial N) (factorial nij) (factorial (- (a i) nij)) (factorial (- (b j) nij)) (factorial (+ (- N (a i) (b j)) nij))))))
 
 (defn cell-triples
   "Generates set of indices for permutation model when calculating expected mutual information."

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -5,13 +5,13 @@
 ;TODO move this to a util NS? Or find a better implementation
 (defn factorial
   [x]
-  (println x)
+  {:pre [(>= x 0)]}
     (if (zero? x)
       1
       (loop [n x f 1]
         (if (= n 1)
             f
-            (recur (dec n) (* f n))))))
+            (recur (dec n) (* f n)))))))
 
 ; The Mutual Information is a measure of the similarity between two labels of the same data.
 ; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample
@@ -65,7 +65,6 @@
         norm_n (into {} (map (fn[[k v]] [k (/ v N)]) n))
         cells (keys norm_n)
         combinations (apply concat (map (fn[[i j]] ((partial triples N a b) i j)) cells))]
-
         (reduce + (map (partial inside-fn N a b) combinations))))
 
 

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -1,0 +1,27 @@
+(ns clojurewerkz.statistiker.metrics)
+
+; Adjusted Mutual Information (AMI) is an adjustment of the Mutual Information (MI) score to account for chance.
+; AMI(U, V) = [MI(U, V) - E(MI(U, V))] / [max(H(U), H(V)) - E(MI(U, V))]
+; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
+
+; This metric is independent of the absolute values of the labels: a permutation of the class 
+; or cluster label values won’t change the score value in any way.
+(defn adjusted_mutual_information
+	[true_labels predicted_labels]
+	{:pre [(= (count true_labels) (count predicted_labels))]}
+	0.0)	
+
+; The Mutual Information is a measure of the similarity between two labels of the same data. 
+; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample 
+; occurring in cluster V_j, the Mutual Information between clusterings U and V is given as:
+; MI(U,V)=\sum_{i=1}^R \sum_{j=1}^C P(i,j)\log\frac{P(i,j)}{P(i)P'(j)}
+; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
+
+; This metric is independent of the absolute values of the labels: a permutation of the class or cluster label 
+; values won’t change the score value in any way.
+(defn mutual_information
+	[true_labels predicted_labels]
+	{:pre [(= (count true_labels) (count predicted_labels))
+		   (not (empty? true_labels))
+		   (not (empty? predicted_labels))]}
+	0.0)

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -38,8 +38,8 @@
   (* (/ nij N)
      (prot-log (/ (* N nij)  (* (a i) (b j))))
      (/
-      (* (factorial (a i)) (factorial (b j)) (factorial (- N (a i))) (factorial (- N (b j))))
-      (* (factorial N) (factorial nij) (factorial (- (a i) nij)) (factorial (- (b j) nij)) (factorial (+ (- N (a i) (b j)) nij))))))
+      (*' (factorial (a i)) (factorial (b j)) (factorial (- N (a i))) (factorial (- N (b j))))
+      (*' (factorial N) (factorial nij) (factorial (- (a i) nij)) (factorial (- (b j) nij)) (factorial (+ (- N (a i) (b j)) nij))))))
 
 (defn cell-triples
   "Generates set of indices for permutation model when calculating expected mutual information."

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -1,18 +1,14 @@
 (ns clojurewerkz.statistiker.metrics
-  (:require [clojure.math.combinatorics :refer [cartesian-product]]))
+  (:require [clojure.math.combinatorics :refer [cartesian-product]]
+            [clojurewerkz.statistiker.entropy :refer [shannon-entropy]]))
 
-; Adjusted Mutual Information (AMI) is an adjustment of the Mutual Information (MI) score to account for chance.
-; AMI(U, V) = [MI(U, V) - E(MI(U, V))] / [max(H(U), H(V)) - E(MI(U, V))]
-; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
-
-; This metric is independent of the absolute values of the labels: a permutation of the class
-; or cluster label values won’t change the score value in any way.
-(defn adjusted_mutual_information
-  [U V]
-  {:pre [(= (count U) (count V))
-         (not-any? coll? U)
-         (not-any? coll? V)]}
-  0.0)
+;TODO move this to a util NS? Or find a better implementation
+(defn factorial
+  [x]
+    (loop [n x f 1]
+        (if (= n 1)
+            f
+            (recur (dec n) (* f n)))))
 
 ; The Mutual Information is a measure of the similarity between two labels of the same data.
 ; Where P(i) is the probability of a random sample occurring in cluster U_i and P'(j) is the probability of a random sample
@@ -38,6 +34,42 @@
                (fn [[i j]]
                  (* (norm_n [i j])
                     (Math/log (/ (norm_n [i j])
-                                         (/ (* (a i) (b j))
-                                            (* N N))))))
+                                 (/ (* (a i) (b j))
+                                    (* N N))))))
                cells))))
+
+;TODO: write this!
+(defn expected_mututal_information
+  [U V]
+   (let [a (frequencies U)
+        b (frequencies V)
+        n (apply merge-with + (map #(hash-map [%1 %2] 1) U V))
+        N (count U)
+        ;; TODO: Use a fmap.
+        norm_n (into {} (map (fn[[k v]] [k (/ v N)]) n))
+        cells (keys norm_n)]
+(reduce + (map
+            (fn [[i j]]
+
+              (/
+               (* (factorial (a i)) (factorial (b j)) (factorial (- N (a i))) (factorial (- N (b j))))
+               (* (factorial N) (n [i j])
+              )
+               cells))))
+
+; Adjusted Mutual Information (AMI) is an adjustment of the Mutual Information (MI) score to account for chance.
+; AMI(U, V) = [MI(U, V) - E(MI(U, V))] / [max(H(U), H(V)) - E(MI(U, V))]
+; It takes a sequence of golden standard cluster labels (e.g,. [1 1 2 2 4 4]) and a set of predicted labels (e.g., [1 1 1 2 4 4])
+
+; This metric is independent of the absolute values of the labels: a permutation of the class
+; or cluster label values won’t change the score value in any way.
+(defn adjusted_mutual_information
+  [U V]
+  {:pre [(= (count U) (count V))
+         (not-any? coll? U)
+         (not-any? coll? V)]}
+  (let [MI (mutual_information U V)
+        EMI (expected_mututal_information U V)
+        h_U (shannon-entropy U)
+        h_V (shannon-entropy V)]
+    (/ (- MI EMI) (- (max h_U h_V) EMI))))

--- a/src/clj/clojurewerkz/statistiker/utils.clj
+++ b/src/clj/clojurewerkz/statistiker/utils.clj
@@ -56,3 +56,36 @@
   [wat center tolerance]
   (and (>= wat (- center tolerance))
        (<= wat (+ center tolerance))))
+
+
+
+;;
+;; Used by metrics 
+;;
+
+(defn factorial
+  "Protected factorial. Special case: returns 1 if x is zero"
+  [x]
+  {:pre [(>= x 0)]}
+    (loop [n x f 1]
+      (if (<= n 1) ; It assigns a value of 1.0 for "(factorial 0)""
+        f
+        (recur (dec n) (* f n)))))
+
+(defn prot-log
+  "Protected-log. Special case: returns 0 if x is equal to 0, instead of indetermination."
+  [x]
+  (if (zero? x)
+    0
+    (Math/log x)))
+
+(defn prot-shannon-entropy
+  "Protected Shannon entropy measure (inc. protected-logarithms)."
+  [v]
+  (let [sum (reduce + v)]
+    (->> v
+         (map (fn shannon-entropy-step [i]
+                (let [pi (/ i sum)]
+                  (* pi (prot-log pi)))))
+         (reduce +)
+         (* -1))))

--- a/src/clj/clojurewerkz/statistiker/utils.clj
+++ b/src/clj/clojurewerkz/statistiker/utils.clj
@@ -70,7 +70,7 @@
     (loop [n x f 1]
       (if (<= n 1) ; It assigns a value of 1.0 for "(factorial 0)""
         f
-        (recur (dec n) (* f n)))))
+        (recur (dec n) (*' f n)))))
 
 (defn prot-log
   "Protected-log. Special case: returns 0 if x is equal to 0, instead of indetermination."

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -2,7 +2,7 @@
   (:require [clojurewerkz.statistiker.metrics :refer :all]
             [clojurewerkz.statistiker.utils :refer [almost=]]
             [clojure.test :refer :all]))
-
+; Tolerance for values
 (def tol 1e-8)
 
 (deftest wrong-input-mi

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -1,0 +1,41 @@
+(ns clojurewerkz.statistiker.metrics-test
+	(:require [clojurewerkz.statistiker.metrics :refer :all]            
+            [clojure.test :refer :all]))
+
+
+(deftest wrong-input-ami
+	(is (thrown? AssertionError (adjusted_mutual_information [1 2 3] [2 3])))
+	(is (thrown? AssertionError (adjusted_mutual_information [] [2 3])))
+	(is (thrown? AssertionError (adjusted_mutual_information [:b :a :c] [2 :a]))))
+
+(deftest wrong-input-mi
+	(is (thrown? AssertionError (mutual_information [1 2 3] [2 3])))
+	(is (thrown? AssertionError (mutual_information [] [2 3])))
+	(is (thrown? AssertionError (mutual_information [:b :a :c] [2 :a])))
+	(is (thrown? AssertionError (mutual_information [] []))))
+
+(deftest adjusted_mutual_information-values
+	(is (= (adjusted_mutual_information [1 2 3] [1 2 3]) 
+			(adjusted_mutual_information [3 2 1] [1 2 3])
+			(adjusted_mutual_information [1 2 3] [:a :b 2])
+			1.0))
+	(is (= (adjusted_mutual_information [] []) 1.0))
+	(is (= (adjusted_mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
+	(is (= (adjusted_mutual_information [:a :a :a :a] [1 1 1 1]) 1.0))
+	(is (= (adjusted_mutual_information [:a 6 :d :f] [1 2 3 4]) 1.0))
+	(is (= (adjusted_mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0))
+	(is (= (adjusted_mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) -0.20000000857324676))
+	(is (= (adjusted_mutual_information [0, 1, 2, 0], [0, 1, 2, 3]) -8.2435062679677756e-09)))
+
+
+(deftest mutual_information-values
+	(is (= (mutual_information [1 2 3] [1 2 3]) 
+			(mutual_information [3 2 1] [1 2 3])
+			(mutual_information [1 2 3] [:a :b 2])
+			1.0986122886681096))
+	(is (= (mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
+	(is (= (mutual_information [:a :a :a :a] [1 1 1 1]) 0.0))
+	(is (= (mutual_information [:a 6 :d :f] [1 2 3 4]) 0.0))
+	(is (= (mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0397207708399179))
+	(is (= (mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) 0.69314718055994518))
+	(is (= (mutual_information [0, 1, 2, 0], [0, 1, 2, 3]) 1.0397207708399179)))

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -1,21 +1,23 @@
 (ns clojurewerkz.statistiker.metrics-test
-	(:require [clojurewerkz.statistiker.metrics :refer :all]            
+	(:require [clojurewerkz.statistiker.metrics :refer :all]
             [clojure.test :refer :all]))
 
 
 (deftest wrong-input-ami
 	(is (thrown? AssertionError (adjusted_mutual_information [1 2 3] [2 3])))
 	(is (thrown? AssertionError (adjusted_mutual_information [] [2 3])))
-	(is (thrown? AssertionError (adjusted_mutual_information [:b :a :c] [2 :a]))))
+	(is (thrown? AssertionError (adjusted_mutual_information [:b :a :c] [2 :a])))
+  (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a]))))
 
 (deftest wrong-input-mi
 	(is (thrown? AssertionError (mutual_information [1 2 3] [2 3])))
 	(is (thrown? AssertionError (mutual_information [] [2 3])))
 	(is (thrown? AssertionError (mutual_information [:b :a :c] [2 :a])))
-	(is (thrown? AssertionError (mutual_information [] []))))
+	(is (thrown? AssertionError (mutual_information [] [])))
+  (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a]))))
 
 (deftest adjusted_mutual_information-values
-	(is (= (adjusted_mutual_information [1 2 3] [1 2 3]) 
+	(is (= (adjusted_mutual_information [1 2 3] [1 2 3])
 			(adjusted_mutual_information [3 2 1] [1 2 3])
 			(adjusted_mutual_information [1 2 3] [:a :b 2])
 			1.0))
@@ -29,7 +31,7 @@
 
 
 (deftest mutual_information-values
-	(is (= (mutual_information [1 2 3] [1 2 3]) 
+	(is (= (mutual_information [1 2 3] [1 2 3])
 			(mutual_information [3 2 1] [1 2 3])
 			(mutual_information [1 2 3] [:a :b 2])
 			1.0986122886681096))

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -1,6 +1,7 @@
 (ns clojurewerkz.statistiker.metrics-test
 	(:require [clojurewerkz.statistiker.metrics :refer :all]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            ))
 
 
 (deftest wrong-input-ami
@@ -35,9 +36,10 @@
 			(mutual_information [3 2 1] [1 2 3])
 			(mutual_information [1 2 3] [:a :b 2])
 			1.0986122886681096))
+  (is (= (mutual_information [1 1 1] [1 1 1]) 0.0))
 	(is (= (mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
 	(is (= (mutual_information [:a :a :a :a] [1 1 1 1]) 0.0))
-	(is (= (mutual_information [:a 6 :d :f] [1 2 3 4]) 0.0))
+	(is (= (mutual_information [:a 6 :d :f] [1 2 3 4]) 1.3862943611198906))
 	(is (= (mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0397207708399179))
-	(is (= (mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) 0.69314718055994518))
+	(is (= (mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) 0.6931471805599453))
 	(is (= (mutual_information [0, 1, 2, 0], [0, 1, 2, 3]) 1.0397207708399179)))

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -1,45 +1,49 @@
 (ns clojurewerkz.statistiker.metrics-test
-	(:require [clojurewerkz.statistiker.metrics :refer :all]
-            [clojure.test :refer :all]
-            ))
+  (:require [clojurewerkz.statistiker.metrics :refer :all]
+            [clojurewerkz.statistiker.utils :refer [almost=]]
+            [clojure.test :refer :all]))
 
-
-(deftest wrong-input-ami
-	(is (thrown? AssertionError (adjusted_mutual_information [1 2 3] [2 3])))
-	(is (thrown? AssertionError (adjusted_mutual_information [] [2 3])))
-	(is (thrown? AssertionError (adjusted_mutual_information [:b :a :c] [2 :a])))
-  (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a]))))
+(def tol 1e-8)
 
 (deftest wrong-input-mi
-	(is (thrown? AssertionError (mutual_information [1 2 3] [2 3])))
-	(is (thrown? AssertionError (mutual_information [] [2 3])))
-	(is (thrown? AssertionError (mutual_information [:b :a :c] [2 :a])))
-	(is (thrown? AssertionError (mutual_information [] [])))
-  (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a]))))
+  (testing "invalid inputs for mutual_information"
+    (is (thrown? AssertionError (mutual_information [1 2 3] [2 3])))
+    (is (thrown? AssertionError (mutual_information [] [2 3])))
+    (is (thrown? AssertionError (mutual_information [:b :a :c] [2 :a])))
+    (is (thrown? AssertionError (mutual_information [] [])))
+    (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a])))))
 
-(deftest adjusted_mutual_information-values
-	(is (= (adjusted_mutual_information [1 2 3] [1 2 3])
-			(adjusted_mutual_information [3 2 1] [1 2 3])
-			(adjusted_mutual_information [1 2 3] [:a :b 2])
-			1.0))
-;; 	(is (= (adjusted_mutual_information [] []) 1.0))  ;TODO check with Miguel
-	(is (==(adjusted_mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
-	(is (= (adjusted_mutual_information [:a :a :a :a] [1 1 1 1]) 1.0))
-	(is (= (adjusted_mutual_information [:a 6 :d :f] [1 2 3 4]) 1.0))
-	(is (= (adjusted_mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0))
-	(is (= (adjusted_mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) -0.20000000857324676))
-	(is (= (adjusted_mutual_information [0, 1, 2, 0], [0, 1, 2, 3]) -8.2435062679677756e-09)))
-
+(deftest wrong-input-ami
+  (testing "invalid inputs for adjusted_mutual_information"
+    (is (thrown? AssertionError (adjusted_mutual_information [1 2 3] [2 3])))
+    (is (thrown? AssertionError (adjusted_mutual_information [] [2 3])))
+    (is (thrown? AssertionError (adjusted_mutual_information [:b :a :c] [2 :a])))
+    (is (thrown? AssertionError (adjusted_mutual_information [[:b :a] :c] [2 :a])))))
 
 (deftest mutual_information-values
-	(is (= (mutual_information [1 2 3] [1 2 3])
-			(mutual_information [3 2 1] [1 2 3])
-			(mutual_information [1 2 3] [:a :b 2])
-			1.0986122886681096))
-  (is (= (mutual_information [1 1 1] [1 1 1]) 0.0))
-	(is (= (mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
-	(is (= (mutual_information [:a :a :a :a] [1 1 1 1]) 0.0))
-	(is (= (mutual_information [:a 6 :d :f] [1 2 3 4]) 1.3862943611198906))
-	(is (= (mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0397207708399179))
-	(is (= (mutual_information [0, 0, 'docid2', 'docid'], [0, 99, 87, 0]) 0.6931471805599453))
-	(is (= (mutual_information [0, 1, 2, 0], [0, 1, 2, 3]) 1.0397207708399179)))
+  (testing "mutual information calculations"
+    (is (= (mutual_information [1 2 3] [1 2 3])
+           (mutual_information [3 2 1] [1 2 3])
+           (mutual_information [1 2 3] [:a :b 2])))
+    (is (almost= (mutual_information [1 2 3] [1 2 3]) 1.0986122886681096 tol))
+    (is (= (mutual_information [1 1 1] [1 1 1]) 0.0))
+    (is (= (mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
+    (is (= (mutual_information [:a :a :a :a] [1 1 1 1]) 0.0))
+    (is (almost= (mutual_information [:a 6 :d :f] [1 2 3 4]) 1.3862943611198906 tol))
+    (is (almost= (mutual_information [0 0 :c2 :c1] [0 0 87 99]) 1.0397207708399179 tol))
+    (is (almost= (mutual_information [0 0 'docid2' 'docid'] [0 99 87 0]) 0.6931471805599453 tol))
+    (is (almost= (mutual_information [0 1 2 0] [0 1 2 3]) 1.0397207708399179 tol))))
+
+(deftest adjusted_mutual_information-values
+  (testing "adjusted mututal information calculations"
+    (is (= (adjusted_mutual_information [1 2 3] [1 2 3])
+           (adjusted_mutual_information [3 2 1] [1 2 3])
+           (adjusted_mutual_information [1 2 3] [:a :b 2])
+           1.0))
+  	(is (= (adjusted_mutual_information [] []) 1.0))
+    (is (==(adjusted_mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
+    (is (= (adjusted_mutual_information [:a :a :a :a] [1 1 1 1]) 1.0))   ;special limit case
+    (is (= (adjusted_mutual_information [:a 6 :d :f] [1 2 3 4]) 1.0))
+    (is (= (adjusted_mutual_information [0 0 :c2 :c1] [0 0 87 99]) 1.0))
+    (is (almost= (adjusted_mutual_information [0 0 'docid2' 'docid'] [0 99 87 0]) -0.20000000000000023 tol))
+    (is (= (adjusted_mutual_information [0 1 2 0] [0 1 2 3]) 0.0))))

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -22,8 +22,8 @@
 			(adjusted_mutual_information [3 2 1] [1 2 3])
 			(adjusted_mutual_information [1 2 3] [:a :b 2])
 			1.0))
-	(is (= (adjusted_mutual_information [] []) 1.0))
-	(is (= (adjusted_mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
+;; 	(is (= (adjusted_mutual_information [] []) 1.0))  ;TODO check with Miguel
+	(is (==(adjusted_mutual_information [1 2 3 4] [1 1 1 1]) 0.0))
 	(is (= (adjusted_mutual_information [:a :a :a :a] [1 1 1 1]) 1.0))
 	(is (= (adjusted_mutual_information [:a 6 :d :f] [1 2 3 4]) 1.0))
 	(is (= (adjusted_mutual_information [0, 0, :c2, :c1], [0, 0, 87, 99]) 1.0))


### PR DESCRIPTION
This is a PR to add Adjusted_Mutual_Information (http://en.wikipedia.org/wiki/Adjusted_mutual_information), a quite common way to evaluate clustering, given a gold standard. Some of the initial values for testing, and the main assumptions, are based on the sklearn implementation. The PR also includes some auxiliary functions that we have refactored into the utils. 

I would love to hear your opinion if the auxiliary functions should stay in the metrics ns or not, and also if the name "metrics" is meaningful enough (again, based on sklearn) or not. 
