### PR TITLE
Cleaner tests and check for non 1 dimensional inputs

### DIFF
--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -90,8 +90,6 @@
   [U V]
   {:pre [(= (count U) (count V))
          (not-any? coll? U)
-         (not-any? coll? V)
-         (not-any? coll? U)
          (not-any? coll? V)]}
   (if (or (empty? U)
           (= 1 (count (distinct U)) (count (distinct V)))          ;only one cluster

--- a/src/clj/clojurewerkz/statistiker/metrics.clj
+++ b/src/clj/clojurewerkz/statistiker/metrics.clj
@@ -19,15 +19,17 @@
 
    This metric is independent of the absolute values of the labels: a permutation of the
    class or cluster label values won’t change the score value in any way."
-  [labels-u labels-v]
-  {:pre [(= (count labels-u) (count labels-v))
-         (not (empty? labels-u))
-         (not (empty? labels-v))]}
-  (let [freq-u        (frequencies labels-u)
-        freq-v        (frequencies labels-v)
-        freq-combined (->> (map vector labels-u labels-v)
+  [U V]
+  {:pre [(= (count U) (count V))
+         (not (empty? U))
+         (not (empty? V))
+         (not-any? coll? U)
+         (not-any? coll? V)]}
+  (let [freq-u        (frequencies U)
+        freq-v        (frequencies V)
+        freq-combined (->> (map vector U V)
                            frequencies)
-        labels-count  (count labels-u)
+        labels-count  (count U)
         norm-n        (zipmap (keys freq-combined)
                               (map #(/ % labels-count) (vals freq-combined)))]
     (->> norm-n
@@ -87,6 +89,8 @@
    or cluster label values won’t change the score value in any way."
   [U V]
   {:pre [(= (count U) (count V))
+         (not-any? coll? U)
+         (not-any? coll? V)
          (not-any? coll? U)
          (not-any? coll? V)]}
   (if (or (empty? U)

--- a/test/clj/clojurewerkz/statistiker/metrics_test.clj
+++ b/test/clj/clojurewerkz/statistiker/metrics_test.clj
@@ -7,43 +7,44 @@
 
 (deftest wrong-input-mi
   (testing "invalid inputs for mutual-information"
-    (is (thrown? AssertionError (mutual-information [1 2 3] [2 3])))
-    (is (thrown? AssertionError (mutual-information [] [2 3])))
-    (is (thrown? AssertionError (mutual-information [:b :a :c] [2 :a])))
-    (is (thrown? AssertionError (mutual-information [] [])))
-    (is (thrown? AssertionError (adjusted_mutual-information [[:b :a] :c] [2 :a])))))
+    (are [U V] (thrown? AssertionError (mutual-information U V))
+      [1 2 3]       [2 3]
+      []            [2 3]
+      [:b :a :c]    [2 :a]
+      []            []
+      [[:b :a] :c]  [2 :a])))
 
 (deftest wrong-input-ami
-  (testing "invalid inputs for adjusted_mutual-information"
-    (is (thrown? AssertionError (adjusted_mutual-information [1 2 3] [2 3])))
-    (is (thrown? AssertionError (adjusted_mutual-information [] [2 3])))
-    (is (thrown? AssertionError (adjusted_mutual-information [:b :a :c] [2 :a])))
-    (is (thrown? AssertionError (adjusted_mutual-information [[:b :a] :c] [2 :a])))))
+  (testing "invalid inputs for adjusted-mutual-information"
+    (are [U V] (thrown? AssertionError (adjusted-mutual-information U V)) 
+      [1 2 3]       [2 3]
+      []            [2 3]
+      [:b :a :c]    [2 :a]
+      [[:b :a] :c]  [2 :a])))
 
 (deftest mutual-information-values
   (testing "mutual information calculations"
-    (is (= (mutual-information [1 2 3] [1 2 3])
-           (mutual-information [3 2 1] [1 2 3])
-           (mutual-information [1 2 3] [:a :b 2])))
-    (is (almost= (mutual-information [1 2 3] [1 2 3]) 1.0986122886681096 tol))
-    (is (= (mutual-information [1 1 1] [1 1 1]) 0.0))
-    (is (= (mutual-information [1 2 3 4] [1 1 1 1]) 0.0))
-    (is (= (mutual-information [:a :a :a :a] [1 1 1 1]) 0.0))
-    (is (almost= (mutual-information [:a 6 :d :f] [1 2 3 4]) 1.3862943611198906 tol))
-    (is (almost= (mutual-information [0 0 :c2 :c1] [0 0 87 99]) 1.0397207708399179 tol))
-    (is (almost= (mutual-information [0 0 'docid2' 'docid'] [0 99 87 0]) 0.6931471805599453 tol))
-    (is (almost= (mutual-information [0 1 2 0] [0 1 2 3]) 1.0397207708399179 tol))))
+    (are [U V s] (almost= (mutual-information U V) s tol)
+      [3 2 1]                 [1 2 3]     1.0986122886681096 
+      [1 2 3]                 [1 2 3]     1.0986122886681096
+      [1 1 1]                 [1 1 1]     0.0
+      [1 2 3 4]               [1 1 1 1]   0.0
+      [:a :a :a :a]           [1 1 1 1]   0.0
+      [:a 6 :d :f]            [1 2 3 4]   1.3862943611198906
+      [0 0 :c2 :c1]           [0 0 87 99] 1.0397207708399179
+      [0 0 'docid2' 'docid']  [0 99 87 0] 0.6931471805599453
+      [0 1 2 0]               [0 1 2 3]   1.0397207708399179)))
 
 (deftest adjusted-mutual-information-values
   (testing "adjusted mututal information calculations"
-    (is (= (adjusted-mutual-information [1 2 3] [1 2 3])
-           (adjusted-mutual-information [3 2 1] [1 2 3])
-           (adjusted-mutual-information [1 2 3] [:a :b 2])
-           1.0))
-  	(is (= (adjusted-mutual-information [] []) 1.0))
-    (is (==(adjusted-mutual-information [1 2 3 4] [1 1 1 1]) 0.0))
-    (is (= (adjusted-mutual-information [:a :a :a :a] [1 1 1 1]) 1.0))   ;special limit case
-    (is (= (adjusted-mutual-information [:a 6 :d :f] [1 2 3 4]) 1.0))
-    (is (= (adjusted-mutual-information [0 0 :c2 :c1] [0 0 87 99]) 1.0))
-    (is (almost= (adjusted-mutual-information [0 0 'docid2' 'docid'] [0 99 87 0]) -0.20000000000000023 tol))
-    (is (= (adjusted-mutual-information [0 1 2 0] [0 1 2 3]) 0.0))))
+    (are [U V s] (almost= (adjusted-mutual-information U V) s tol)
+      [1 2 3]                 [1 2 3]     1.0
+      [3 2 1]                 [1 2 3]     1.0
+      [1 2 3]                 [:a :b 2]   1.0
+      []                      []          1.0
+      [1 2 3 4]               [1 1 1 1]   0.0
+      [:a :a :a :a]           [1 1 1 1]   1.0   ;special limit case
+      [:a 6 :d :f]            [1 2 3 4]   1.0
+      [0 0 :c2 :c1]           [0 0 87 99] 1.0
+      [0 0 'docid2' 'docid']  [0 99 87 0] -0.20000000000000023
+      [0 1 2 0]               [0 1 2 3]   0.0)))


### PR DESCRIPTION
Cleaner tests using 'are' as suggested by @michaelklishin and an extra precondition to check that the structures being passed as arguments for MI and AMI are 1 dimensional.
